### PR TITLE
Add --reset flag to menu

### DIFF
--- a/os/services/menu.service
+++ b/os/services/menu.service
@@ -10,7 +10,7 @@ StartLimitBurst=5
 Environment="MOABIAN=3.0.23"
 Environment="PYTHONUNBUFFERED=1"
 WorkingDirectory=/home/pi/moab/sw
-ExecStart=/usr/bin/python3 menu.py -d -v
+ExecStart=/usr/bin/python3 menu.py --debug --verbose --reset
 User=pi
 
 Restart=on-failure

--- a/sw/menu.py
+++ b/sw/menu.py
@@ -207,6 +207,11 @@ def _handle_debug(ctx, param, debug):
     help=("Enables or disables the logging as specified by -f/--file"),
 )
 @click.option(
+    "-r",
+    "--reset/--no-reset",
+    help="Reset Moab firmware on start"
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -222,7 +227,11 @@ def main(ctx: click.core.Context, **kwargs: Any) -> None:
     main_menu(**kwargs)
 
 
-def main_menu(cont, debug, file, hertz, log, verbose):
+def main_menu(cont, debug, file, hertz, log, reset, verbose):
+
+    if reset:
+        out("Resetting firmware")
+        os.system("raspi-gpio set 6 dh && sleep 0.05 && raspi-gpio set 6 dl")
 
     with MoabEnv(hertz, debug=debug, verbose=verbose) as env:
         menu_list = build_menu(env, log, file)


### PR DESCRIPTION
Since a tap on the power button will "system restart moab", adding the
new --reset flag will send a GPIO signal to quickly (0.05 seconds)
restart the firmware to a known good state.

Only necessary if menu.service crashes.