### PR TITLE
Update setup for raspian bullseye

### DIFF
--- a/os/setup
+++ b/os/setup
@@ -40,7 +40,7 @@ function layer-run-first
     ## Enable ssh by default for Moab
     touch /boot/ssh
 
-    apt-get update -y
+    apt-get update --allow-releaseinfo-change -y
 }
 
 


### PR DESCRIPTION
Added --allow-releaseinfo-change -y to the apt-get update command on line 42 to enable update from raspian buster to bullseye