### PR TITLE
Upgrade opencv to latest release per dependabot #66

### DIFF
--- a/sw/setup/requirements.txt
+++ b/sw/setup/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.20.1
-opencv-python-headless==4.1.0.25
+opencv-python-headless==4.5.3.56
 picamera==1.13
 requests==2.25.1
 dacite==1.6.0


### PR DESCRIPTION
Tested latest OpenCV release from piwheels.org (Python binary wheel packages for Raspberry Pi) per the dependabot suggestion. 

```
pip3 install --user --upgrade opencv-python-headless==4.5.3.56
```

<img width="1013" alt="Looking in indexes httpspypi orgsimple, httpswww piwheels orgsimple" src="https://user-images.githubusercontent.com/58437613/138391258-a9b9f249-1e45-4e93-a8b1-a05226021865.png">
