### PR TITLE
Kiosk mode 

### DIFF
--- a/sw/controllers.py
+++ b/sw/controllers.py
@@ -60,7 +60,7 @@ def dump_ball_controller(angle=90, tilt_angle=16, **kwargs):
         env_state, ball_detected, buttons = state
         a = -tilt_angle * np.cos(np.radians(angle))
         b = -tilt_angle * np.sin(np.radians(angle))
-        action = Vector2(b, a)
+        action = Vector2(a, b)
         return action, {}
 
     return next_action

--- a/sw/controllers.py
+++ b/sw/controllers.py
@@ -53,6 +53,26 @@ def joystick_controller(max_angle=16, **kwargs):
     return next_action
 
 
+def dump_ball_controller(angle=90, tilt_angle=16, **kwargs):
+    """Dump the ball towards angle."""
+
+    def next_action(state):
+        env_state, ball_detected, buttons = state
+        a = -tilt_angle * np.cos(np.radians(angle))
+        b = -tilt_angle * np.sin(np.radians(angle))
+        action = Vector2(b, a)
+        return action, {}
+
+    return next_action
+
+
+def zero_controller(**kwargs):
+    def next_action(state):
+        return Vector2(0.0, 0.0), {}
+
+    return next_action
+
+
 def brain_controller(
     max_angle=22,
     port=5555,


### PR DESCRIPTION
An additional mode in menu.py that can be accessed by command-line flags.
Used for cases when demoing the MOAB where it's always on. This mode turns off the servos intermittently to protect the hardware.

- After a set number of seconds (300 seconds/5 minutes by default) stop the controller
- Roll the ball towards one side (can be specified by command-line flags), angle in degrees, and follows clock face
- Turn off the servos
- Keep looking in the camera for a ball
- When a ball is detected again turn on the servos and go back to the original controller that was running
