### PR TITLE
Flask and click dependency fix

### DIFF
--- a/sw/setup/requirements.txt
+++ b/sw/setup/requirements.txt
@@ -11,7 +11,7 @@ Flask==2.1.0
 inotify==0.2.10
 gunicorn==20.0.4
 pyserial==3.5
-click==7.1.2
+click==8.1.3
 black==20.8b1
 psutil==5.8.0
 pyyaml==5.4.1


### PR DESCRIPTION
Flask 2.1.0 fix from earlier exposed a click version incompatibility. Fixed by pinning `click` to 8.1.3